### PR TITLE
Fix URDF path in launch script

### DIFF
--- a/src/boxygo/launch/view_launch.py
+++ b/src/boxygo/launch/view_launch.py
@@ -8,7 +8,9 @@ import os
 
 def generate_launch_description():
     pkg_boxygo = get_package_share_directory('boxygo')
-    urdf_path = os.path.join(pkg_boxygo, 'urdf', '6_wheel_robot_v2.urdf.xacro')
+    # This launch file referenced a URDF that does not exist. Use the
+    # available robot description instead.
+    urdf_path = os.path.join(pkg_boxygo, 'urdf', '6_wheel_robot.urdf.xacro')
 
     # Pusty świat z Gazebo (domyślny empty.world, możesz podać swój jeśli masz)
     gazebo_launch = IncludeLaunchDescription(


### PR DESCRIPTION
## Summary
- use existing URDF in `view_launch.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for ROS test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684a082815288330a0ebefcb842dac55